### PR TITLE
Fix property duplication from previously parsed card

### DIFF
--- a/src/text_io.cpp
+++ b/src/text_io.cpp
@@ -181,6 +181,10 @@ std::vector<vCard> TextReader::parseCards()
             started = true;
         } else if ((line == VC_END_TOKEN) && started) {
             vcards.push_back(current);
+            
+            // Empty the current card
+            current = vCard();
+            
             started = false;
         } else if ((line.find("VERSION") != std::string::npos) && started) {
             size_t pos = line.find(":");


### PR DESCRIPTION
The TextReader didn't clear the current vCard working object.

I'm not sure why the GitHub editor adds an a new line at the end of the file