### PR TITLE
Return empty default string as version

### DIFF
--- a/src/vcard.cpp
+++ b/src/vcard.cpp
@@ -204,5 +204,8 @@ std::string vCard::getVersionStr()
 
         case VC_VER_4_0:
             return "4.0";
+
+        default: 
+            return "";
     }
 }


### PR DESCRIPTION
Whenever the version does not match and empty string will be returned